### PR TITLE
[#30] 채팅방 메세지 전송 수정, 에러 메세지 세분화

### DIFF
--- a/src/main/java/com/leteatgo/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/leteatgo/domain/chat/controller/ChatMessageController.java
@@ -1,16 +1,22 @@
 package com.leteatgo.domain.chat.controller;
 
 import static com.leteatgo.global.constants.Destination.CHAT_ROOM;
+import static org.springframework.messaging.simp.SimpMessageHeaderAccessor.SESSION_ATTRIBUTES;
 
 import com.leteatgo.domain.chat.dto.ChatMessageDto;
+import com.leteatgo.domain.chat.dto.response.ChatMessageResponse;
 import com.leteatgo.domain.chat.service.ChatMessageService;
 import java.security.Principal;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RequiredArgsConstructor
 @RestController
 public class ChatMessageController {
@@ -19,9 +25,14 @@ public class ChatMessageController {
     private final ChatMessageService chatMessageService;
 
     @MessageMapping("/rooms/message")
-    public void sendMessage(@Payload ChatMessageDto chatMessageDto, Principal principal) {
-        chatMessageService.saveMessage(chatMessageDto, principal.getName());
-        messagingTemplate.convertAndSend(CHAT_ROOM + chatMessageDto.roomId(),
-                chatMessageDto);
+    public void sendMessage(@Payload ChatMessageDto chatMessageDto, Principal principal,
+            @Header(SESSION_ATTRIBUTES) Map<String, Object> sessionAttributes) {
+        Long roomId = (Long) sessionAttributes.get("roomId");
+        ChatMessageResponse chatMessageResponse = chatMessageService.saveMessage(chatMessageDto,
+                principal.getName(), roomId);
+
+        messagingTemplate.convertAndSend(CHAT_ROOM + roomId, chatMessageResponse);
+        log.info("[ws] send message [{}]", roomId);
     }
+
 }

--- a/src/main/java/com/leteatgo/domain/chat/dto/ChatMessageDto.java
+++ b/src/main/java/com/leteatgo/domain/chat/dto/ChatMessageDto.java
@@ -2,10 +2,7 @@ package com.leteatgo.domain.chat.dto;
 
 import com.leteatgo.domain.chat.entity.ChatMessage;
 
-public record ChatMessageDto(
-        Long roomId,
-        String message
-) {
+public record ChatMessageDto(String message) {
 
     public ChatMessage toEntity() {
         return new ChatMessage(message);

--- a/src/main/java/com/leteatgo/domain/chat/dto/response/MyChatRoomResponse.java
+++ b/src/main/java/com/leteatgo/domain/chat/dto/response/MyChatRoomResponse.java
@@ -3,24 +3,24 @@ package com.leteatgo.domain.chat.dto.response;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.leteatgo.global.type.RestaurantCategory;
 import java.time.LocalDateTime;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Builder
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
-public class MyChatRoomResponse {
+public record MyChatRoomResponse(
+        String meetingName,
+        RestaurantCategory category,
+        String region,
+        Chat chat
+) {
 
-    private String meetingName;
-    private RestaurantCategory category;
-    private String region;
-    private Long roomId;
-    private String content;
-    private boolean isRead;
+    @Builder
+    public record Chat(
+            Long roomId,
+            String content,
+            boolean isRead,
+            @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+            LocalDateTime createdAt
+    ) {
 
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-    private LocalDateTime createdAt;
+    }
 }

--- a/src/main/java/com/leteatgo/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/leteatgo/domain/chat/service/ChatMessageService.java
@@ -3,6 +3,7 @@ package com.leteatgo.domain.chat.service;
 import static com.leteatgo.global.exception.ErrorCode.NOT_FOUND_CHATROOM;
 
 import com.leteatgo.domain.chat.dto.ChatMessageDto;
+import com.leteatgo.domain.chat.dto.response.ChatMessageResponse;
 import com.leteatgo.domain.chat.entity.ChatMessage;
 import com.leteatgo.domain.chat.entity.ChatRoom;
 import com.leteatgo.domain.chat.exception.ChatException;
@@ -11,12 +12,9 @@ import com.leteatgo.domain.chat.repository.ChatRoomRepository;
 import com.leteatgo.domain.member.entity.Member;
 import com.leteatgo.global.security.CustomUserDetailService;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Slf4j
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Service
@@ -26,17 +24,17 @@ public class ChatMessageService {
     private final ChatRoomRepository chatRoomRepository;
     private final CustomUserDetailService userDetailService;
 
-    @Async
     @Transactional
-    public void saveMessage(ChatMessageDto message, String authId) {
+    public ChatMessageResponse saveMessage(ChatMessageDto message, String authId, Long roomId) {
         Member sender = userDetailService.findByIdOrThrow(Long.parseLong(authId));
-        ChatRoom chatRoom = chatRoomRepository.findById(message.roomId())
+
+        ChatRoom chatRoom = chatRoomRepository.findById(roomId)
                 .orElseThrow(() -> new ChatException(NOT_FOUND_CHATROOM));
 
         ChatMessage chatMessage = message.toEntity();
         chatMessage.setSender(sender);
         chatMessage.setChatRoom(chatRoom);
 
-        chatMessageRepository.save(chatMessage);
+        return ChatMessageResponse.fromEntity(chatMessageRepository.save(chatMessage));
     }
 }

--- a/src/main/java/com/leteatgo/global/exception/ErrorCode.java
+++ b/src/main/java/com/leteatgo/global/exception/ErrorCode.java
@@ -48,6 +48,7 @@ public enum ErrorCode {
     NOT_FOUND_CHATROOM(NOT_FOUND, "존재하지 않는 채팅방입니다."),
     ALREADY_CLOSED_CHATROOM(BAD_REQUEST, "이미 종료된 채팅방입니다."),
     ILLEGAL_DESTINATION(BAD_REQUEST, "잘못된 구독 경로입니다."),
+    NOT_JOINED_CHATROOM(BAD_REQUEST, "참여하지 않은 채팅방입니다."),
 
     // meeting
     NOT_FOUND_MEETING(BAD_REQUEST, "존재하지 않는 모임입니다."),

--- a/src/test/java/com/leteatgo/domain/chat/controller/ChatRoomControllerTest.java
+++ b/src/test/java/com/leteatgo/domain/chat/controller/ChatRoomControllerTest.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.leteatgo.domain.chat.dto.response.ChatMessageResponse;
 import com.leteatgo.domain.chat.dto.response.ChatMessageResponse.Sender;
 import com.leteatgo.domain.chat.dto.response.MyChatRoomResponse;
+import com.leteatgo.domain.chat.dto.response.MyChatRoomResponse.Chat;
 import com.leteatgo.domain.chat.service.ChatRoomService;
 import com.leteatgo.domain.member.entity.Member;
 import com.leteatgo.global.dto.CustomPageRequest;
@@ -109,13 +110,17 @@ class ChatRoomControllerTest {
         String authId = "1";
         CustomPageRequest customPageRequest = new CustomPageRequest(1);
 
+        Chat chat = Chat.builder()
+                .roomId(1L)
+                .content("recent message")
+                .isRead(false)
+                .build();
+
         List<MyChatRoomResponse> contents = List.of(MyChatRoomResponse.builder()
                 .meetingName("meeting name")
                 .category(RestaurantCategory.ASIAN_CUISINE)
                 .region("지역")
-                .roomId(1L)
-                .content("recent message")
-                .isRead(false)
+                .chat(chat)
                 .build());
 
         given(chatRoomService.myChatRooms(authId, customPageRequest))

--- a/src/test/java/com/leteatgo/domain/chat/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/leteatgo/domain/chat/service/ChatRoomServiceTest.java
@@ -18,6 +18,7 @@ import static org.mockito.BDDMockito.given;
 
 import com.leteatgo.domain.chat.dto.response.ChatMessageResponse;
 import com.leteatgo.domain.chat.dto.response.MyChatRoomResponse;
+import com.leteatgo.domain.chat.dto.response.MyChatRoomResponse.Chat;
 import com.leteatgo.domain.chat.entity.ChatMessage;
 import com.leteatgo.domain.chat.entity.ChatRoom;
 import com.leteatgo.domain.chat.event.dto.CloseChatRoomEvent;
@@ -113,6 +114,7 @@ class ChatRoomServiceTest {
     @Nested
     @DisplayName("채팅방 종료 메서드는")
     class CloseChatRoomMethod {
+
         Long meetingId = 1L;
         Meeting meeting = Meeting.builder().build();
         ChatRoom chatRoom = new ChatRoom(OPEN, meeting);
@@ -169,6 +171,7 @@ class ChatRoomServiceTest {
     @Nested
     @DisplayName("채팅방 대화 목록 조회 메서드는")
     class RoomMessagesMethod {
+
         String authId = "1";
         Long roomId = 1L;
         CustomPageRequest customPageRequest = new CustomPageRequest(1);
@@ -262,18 +265,23 @@ class ChatRoomServiceTest {
     @Nested
     @DisplayName("내 채팅방 목록 조회 메서드는")
     class MyChatRoomMethod {
+
         String authId = "1";
         CustomPageRequest customPageRequest = new CustomPageRequest(1);
         Member member = Member.builder().build();
         Pageable pageable = PageRequest.of(customPageRequest.page(), 10);
 
+        Chat chat = Chat.builder()
+                .roomId(1L)
+                .content("recent message")
+                .isRead(false)
+                .build();
+
         List<MyChatRoomResponse> contents = List.of(MyChatRoomResponse.builder()
                 .meetingName("meeting name")
                 .category(RestaurantCategory.ASIAN_CUISINE)
                 .region("지역")
-                .roomId(1L)
-                .content("recent message")
-                .isRead(false)
+                .chat(chat)
                 .build());
 
         @Test


### PR DESCRIPTION
<!-- 제목은 `[#이슈번호] 제목` 으로 작성한다. ex) [#8] 결제 기능 -->

### 🌱 작업 사항
- 채팅 도메인 리팩터링
### ❓ 리뷰 포인트
- StompInterceptor에서 연결/구독 시 에러 메세지 세분화
- 채팅 메세지 전송 로직 수정
  - 기존에는 메세지를 빠르게 전송하기 위해 요청된 메세지 전송과 저장을 비동기로 처리하였다.
  - 그래서 메세지가 제대로 저장되든 말든 메세지는 전송되었기 때문에 이와같은 문제가 발생했다.
  - 해결
    - 비동기 처리를 삭제하고, 제대로 저장되지 않으면 에러가 발생한다.
- 채팅 메세지 예외처리
  - @MessageMapping의 경로와 다른 경로로 메세지 전송 요청을 해도 에러가 발생하지 않았다.
  - 해결
    - 전송 경로에서 목적지를 제거하고, 구독하는 채팅방에게만 메세지를 전송할 수 있도록 로직을 수정하였다.

(이전 pr에서 dev 브랜치를 풀받지 않았었나봐요.. 커밋 메세지가 섞여서 다시 올립니다.)
<!-- ex) query가 너무 많이 나가는 것 같아요 -->
<!-- ex) service 로직 너무 뚱뚱해요 -->
<!-- ex) 테스트 어떤가요. -->

### 🦄 관련 이슈

resolves #30  <!-- pr이 머지되면 이슈가 자동으로 close되게 합니다. 만약 자동 close를 하지 않고 이슈만 링크한다면 resolves를 삭제한다.-->