### PR TITLE
[#38] 모임 상태 배치처리, 모임 리마인드 알림

### DIFF
--- a/src/main/java/com/leteatgo/domain/meeting/repository/CustomMeetingRepository.java
+++ b/src/main/java/com/leteatgo/domain/meeting/repository/CustomMeetingRepository.java
@@ -23,6 +23,6 @@ public interface CustomMeetingRepository {
 
     Optional<Meeting> findMeetingFetch(Long meetingId);
 
-    List<Meeting> findMeetingsForRemind(LocalDateTime now, LocalDateTime otherDateTime,
+    List<Meeting> findMeetingsForRemind(LocalDateTime localDateTime, LocalDateTime otherDateTime,
             MeetingStatus status);
 }

--- a/src/main/java/com/leteatgo/domain/meeting/repository/CustomMeetingRepository.java
+++ b/src/main/java/com/leteatgo/domain/meeting/repository/CustomMeetingRepository.java
@@ -17,9 +17,12 @@ public interface CustomMeetingRepository {
 
     Slice<MeetingListResponse> findMeetingList(String category, String region, Pageable pageable);
 
-    List<Meeting> findMeetingsForUpdateStatus(LocalDateTime startDateTime, MeetingStatus status);
-    
+    List<Meeting> findMeetingsForUpdateStatus(LocalDateTime now, MeetingStatus status);
+
     Slice<MeetingSearchResponse> searchMeetings(String type, String term, Pageable pageable);
 
     Optional<Meeting> findMeetingFetch(Long meetingId);
+
+    List<Meeting> findMeetingsForRemind(LocalDateTime now, LocalDateTime otherDateTime,
+            MeetingStatus status);
 }

--- a/src/main/java/com/leteatgo/domain/meeting/repository/CustomMeetingRepository.java
+++ b/src/main/java/com/leteatgo/domain/meeting/repository/CustomMeetingRepository.java
@@ -17,8 +17,8 @@ public interface CustomMeetingRepository {
 
     Slice<MeetingListResponse> findMeetingList(String category, String region, Pageable pageable);
 
-    List<Meeting> findMeetingsForCancel(LocalDateTime startDateTime, MeetingStatus status);
-
+    List<Meeting> findMeetingsForUpdateStatus(LocalDateTime startDateTime, MeetingStatus status);
+    
     Slice<MeetingSearchResponse> searchMeetings(String type, String term, Pageable pageable);
 
     Optional<Meeting> findMeetingFetch(Long meetingId);

--- a/src/main/java/com/leteatgo/domain/meeting/repository/impl/CustomMeetingRepositoryImpl.java
+++ b/src/main/java/com/leteatgo/domain/meeting/repository/impl/CustomMeetingRepositoryImpl.java
@@ -39,11 +39,14 @@ public class CustomMeetingRepositoryImpl implements CustomMeetingRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<Meeting> findMeetingsForUpdateStatus(LocalDateTime startDateTime,
+    public List<Meeting> findMeetingsForUpdateStatus(LocalDateTime now,
             MeetingStatus status) {
         return queryFactory
                 .selectFrom(meeting)
-                .where(meeting.startDateTime.loe(startDateTime)
+                .join(meeting.meetingParticipants, meetingParticipant).fetchJoin()
+                .join(meetingParticipant.member, member).fetchJoin()
+                .join(meeting.chatRoom, chatRoom).fetchJoin()
+                .where(meeting.startDateTime.loe(now)
                         .and(meeting.meetingOptions.status.eq(status)))
                 .fetch();
     }
@@ -166,5 +169,18 @@ public class CustomMeetingRepositoryImpl implements CustomMeetingRepository {
                 .join(meeting.chatRoom, chatRoom).fetchJoin()
                 .where(meeting.id.eq(meetingId))
                 .fetchOne());
+    }
+
+    @Override
+    public List<Meeting> findMeetingsForRemind(LocalDateTime now, LocalDateTime otherDateTime,
+            MeetingStatus status) {
+        return queryFactory
+                .selectFrom(meeting)
+                .join(meeting.meetingParticipants, meetingParticipant).fetchJoin()
+                .join(meetingParticipant.member, member).fetchJoin()
+                .join(meeting.chatRoom, chatRoom).fetchJoin()
+                .where(meeting.startDateTime.between(now, otherDateTime)
+                        .and(meeting.meetingOptions.status.eq(status)))
+                .fetch();
     }
 }

--- a/src/main/java/com/leteatgo/domain/meeting/repository/impl/CustomMeetingRepositoryImpl.java
+++ b/src/main/java/com/leteatgo/domain/meeting/repository/impl/CustomMeetingRepositoryImpl.java
@@ -172,14 +172,14 @@ public class CustomMeetingRepositoryImpl implements CustomMeetingRepository {
     }
 
     @Override
-    public List<Meeting> findMeetingsForRemind(LocalDateTime now, LocalDateTime otherDateTime,
-            MeetingStatus status) {
+    public List<Meeting> findMeetingsForRemind(LocalDateTime localDateTime,
+            LocalDateTime otherDateTime, MeetingStatus status) {
         return queryFactory
                 .selectFrom(meeting)
                 .join(meeting.meetingParticipants, meetingParticipant).fetchJoin()
                 .join(meetingParticipant.member, member).fetchJoin()
                 .join(meeting.chatRoom, chatRoom).fetchJoin()
-                .where(meeting.startDateTime.between(now, otherDateTime)
+                .where(meeting.startDateTime.between(localDateTime, otherDateTime)
                         .and(meeting.meetingOptions.status.eq(status)))
                 .fetch();
     }

--- a/src/main/java/com/leteatgo/domain/meeting/repository/impl/CustomMeetingRepositoryImpl.java
+++ b/src/main/java/com/leteatgo/domain/meeting/repository/impl/CustomMeetingRepositoryImpl.java
@@ -39,7 +39,8 @@ public class CustomMeetingRepositoryImpl implements CustomMeetingRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<Meeting> findMeetingsForCancel(LocalDateTime startDateTime, MeetingStatus status) {
+    public List<Meeting> findMeetingsForUpdateStatus(LocalDateTime startDateTime,
+            MeetingStatus status) {
         return queryFactory
                 .selectFrom(meeting)
                 .where(meeting.startDateTime.loe(startDateTime)

--- a/src/main/java/com/leteatgo/domain/notification/type/NotificationType.java
+++ b/src/main/java/com/leteatgo/domain/notification/type/NotificationType.java
@@ -1,5 +1,11 @@
 package com.leteatgo.domain.notification.type;
 
 public enum NotificationType {
-    REMIND, CANCEL
+    REMIND("모임 리마인드"),
+    CANCEL("모임 취소"),
+    COMPLETED("모임 완료");
+
+    NotificationType(String description) {
+    }
+
 }

--- a/src/main/java/com/leteatgo/global/batch/meeting/CompleteMeetingsConfig.java
+++ b/src/main/java/com/leteatgo/global/batch/meeting/CompleteMeetingsConfig.java
@@ -101,7 +101,7 @@ public class CompleteMeetingsConfig extends DefaultBatchConfiguration {
                     .userId(participant.getMember().getId().toString())
                     .message(message)
                     .type(NotificationType.COMPLETED)
-                    .relatedUrl("/api/meetings/detail/" + meeting.getId()) // TODO: 프론트 URL로 변경
+                    .relatedUrl("/" + meeting.getId())
                     .build();
             notificationEventPublisher.publishEvent(event);
             log.info("NotificationEvent published: {}", event);

--- a/src/main/java/com/leteatgo/global/batch/meeting/CompleteMeetingsConfig.java
+++ b/src/main/java/com/leteatgo/global/batch/meeting/CompleteMeetingsConfig.java
@@ -1,0 +1,118 @@
+package com.leteatgo.global.batch.meeting;
+
+import static com.leteatgo.global.constants.BeanPrefix.COMPLETE_MEETING;
+import static com.leteatgo.global.constants.Notification.MEETING_COMPLETE;
+
+import com.leteatgo.domain.chat.event.ChatRoomEventPublisher;
+import com.leteatgo.domain.chat.event.dto.CloseChatRoomEvent;
+import com.leteatgo.domain.meeting.entity.Meeting;
+import com.leteatgo.domain.meeting.entity.MeetingParticipant;
+import com.leteatgo.domain.meeting.repository.MeetingRepository;
+import com.leteatgo.domain.meeting.type.MeetingStatus;
+import com.leteatgo.domain.notification.event.NotificationEvent;
+import com.leteatgo.domain.notification.event.NotificationEventPublisher;
+import com.leteatgo.domain.notification.type.NotificationType;
+import java.time.LocalDateTime;
+import java.util.Iterator;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobScope;
+import org.springframework.batch.core.configuration.support.DefaultBatchConfiguration;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.launch.support.RunIdIncrementer;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@RequiredArgsConstructor
+@Configuration
+@Slf4j
+public class CompleteMeetingsConfig extends DefaultBatchConfiguration {
+
+    private final static Integer CHUNK_SIZE = 100;
+
+    private final MeetingRepository meetingRepository;
+    private final ChatRoomEventPublisher chatRoomEventPublisher;
+    private final NotificationEventPublisher notificationEventPublisher;
+
+    @Bean(COMPLETE_MEETING + "Job")
+    public Job job() {
+        return new JobBuilder(COMPLETE_MEETING + "Job", jobRepository())
+                .incrementer(new RunIdIncrementer())
+                .start(completeMeetingStep())
+                .build();
+    }
+
+    @Bean(COMPLETE_MEETING + "Step")
+    @JobScope
+    public Step completeMeetingStep() {
+        return new StepBuilder(COMPLETE_MEETING + "Step", jobRepository())
+                .<Meeting, Meeting>chunk(CHUNK_SIZE, getTransactionManager())
+                .reader(reader())
+                .processor(processor())
+                .writer(writer())
+                .build();
+    }
+
+    @Bean(COMPLETE_MEETING + "Reader")
+    public ItemReader<Meeting> reader() {
+        return new ItemReader<>() {
+            private Iterator<Meeting> meetingIterator;
+
+            @Override
+            public Meeting read() {
+                if (meetingIterator == null) {
+                    LocalDateTime startDateTime = LocalDateTime.now();
+                    meetingIterator = meetingRepository.findMeetingsForUpdateStatus(
+                            startDateTime, MeetingStatus.IN_PROGRESS).iterator();
+                }
+
+                if (meetingIterator.hasNext()) {
+                    return meetingIterator.next();
+                } else {
+                    return null;
+                }
+            }
+        };
+    }
+
+    @Bean(COMPLETE_MEETING + "Processor")
+    public ItemProcessor<Meeting, Meeting> processor() {
+        return meeting -> {
+            meeting.complete();
+            chatRoomEventPublisher.publishCloseChatRoom(new CloseChatRoomEvent(meeting.getId()));
+            publishNotificationForCompleteMeeting(meeting);
+            return meeting;
+        };
+    }
+
+    private void publishNotificationForCompleteMeeting(Meeting meeting) {
+        List<MeetingParticipant> participants = meeting.getMeetingParticipants();
+
+        for (MeetingParticipant participant : participants) {
+            String message = String.format(MEETING_COMPLETE, meeting.getName());
+            NotificationEvent event = NotificationEvent.builder()
+                    .userId(participant.getMember().getId().toString())
+                    .message(message)
+                    .type(NotificationType.COMPLETED)
+                    .relatedUrl("/api/meetings/detail/" + meeting.getId()) // TODO: 프론트 URL로 변경
+                    .build();
+            notificationEventPublisher.publishEvent(event);
+            log.info("NotificationEvent published: {}", event);
+        }
+    }
+
+    @Bean(COMPLETE_MEETING + "Writer")
+    public ItemWriter<Meeting> writer() {
+        return chunk -> {
+            List<? extends Meeting> meetings = chunk.getItems();
+            meetingRepository.saveAll(meetings);
+        };
+    }
+}

--- a/src/main/java/com/leteatgo/global/batch/meeting/RemindMeetingsBeforeOneDayConfig.java
+++ b/src/main/java/com/leteatgo/global/batch/meeting/RemindMeetingsBeforeOneDayConfig.java
@@ -103,7 +103,7 @@ public class RemindMeetingsBeforeOneDayConfig extends DefaultBatchConfiguration 
                     .userId(participant.getMember().getId().toString())
                     .message(message)
                     .type(NotificationType.REMIND)
-                    .relatedUrl("/api/meetings/detail/" + meeting.getId()) // TODO: 프론트 URL로 변경
+                    .relatedUrl("/" + meeting.getId())
                     .build();
             notificationEventPublisher.publishEvent(event);
             log.info("NotificationEvent published: {}", event);

--- a/src/main/java/com/leteatgo/global/batch/meeting/RemindMeetingsBeforeOneDayConfig.java
+++ b/src/main/java/com/leteatgo/global/batch/meeting/RemindMeetingsBeforeOneDayConfig.java
@@ -63,11 +63,11 @@ public class RemindMeetingsBeforeOneDayConfig extends DefaultBatchConfiguration 
             @Override
             public Meeting read() {
                 if (meetingIterator == null) {
-                    LocalDateTime now = LocalDateTime.now();
-                    LocalDateTime oneDayLater = now.plusDays(1)
-                            .plusHours(4); // 매일 저녁 8시에 배치가 수행되기 때문에 4시간을 더함
+                    // 매일 저녁 8시에 배치가 수행되기 때문에 4시간을 더함
+                    LocalDateTime localDateTime = LocalDateTime.now().plusHours(4);
+                    LocalDateTime oneDayLater = localDateTime.plusDays(1);
                     meetingIterator = meetingRepository.findMeetingsForRemind(
-                            now, oneDayLater, MeetingStatus.IN_PROGRESS).iterator();
+                            localDateTime, oneDayLater, MeetingStatus.IN_PROGRESS).iterator();
                 }
 
                 if (meetingIterator.hasNext()) {

--- a/src/main/java/com/leteatgo/global/batch/meeting/RemindUpcomingMeetingsConfig.java
+++ b/src/main/java/com/leteatgo/global/batch/meeting/RemindUpcomingMeetingsConfig.java
@@ -106,7 +106,7 @@ public class RemindUpcomingMeetingsConfig extends DefaultBatchConfiguration {
                     .userId(participant.getMember().getId().toString())
                     .message(message)
                     .type(NotificationType.REMIND)
-                    .relatedUrl("/api/meetings/detail/" + meeting.getId()) // TODO: 프론트 URL로 변경
+                    .relatedUrl("/" + meeting.getId())
                     .build();
             notificationEventPublisher.publishEvent(event);
             log.info("NotificationEvent published: {}", event);

--- a/src/main/java/com/leteatgo/global/batch/meeting/UpdateMeetingsStatusConfig.java
+++ b/src/main/java/com/leteatgo/global/batch/meeting/UpdateMeetingsStatusConfig.java
@@ -106,7 +106,7 @@ public class UpdateMeetingsStatusConfig extends DefaultBatchConfiguration {
                     .userId(participant.getMember().getId().toString())
                     .message(message)
                     .type(NotificationType.CANCEL)
-                    .relatedUrl("/api/meetings/detail/" + meeting.getId()) // TODO: 프론트 URL로 변경
+                    .relatedUrl("/" + meeting.getId())
                     .build();
             notificationEventPublisher.publishEvent(event);
             log.info("NotificationEvent published: {}", event);

--- a/src/main/java/com/leteatgo/global/batch/scheduler/BatchScheduler.java
+++ b/src/main/java/com/leteatgo/global/batch/scheduler/BatchScheduler.java
@@ -40,8 +40,7 @@ public class BatchScheduler {
     }
 
     // 매일 자정에 실행
-//    @Scheduled(cron = "0 0 0 * * *")
-    @Scheduled(cron = "0/30 * * * * *")
+    @Scheduled(cron = "0 0 0 * * *")
     public void runCompleteMeetingsJob() {
         JobParameters jobParameters = new JobParametersBuilder()
                 .addDate("date", new Date())

--- a/src/main/java/com/leteatgo/global/batch/scheduler/BatchScheduler.java
+++ b/src/main/java/com/leteatgo/global/batch/scheduler/BatchScheduler.java
@@ -1,5 +1,6 @@
 package com.leteatgo.global.batch.scheduler;
 
+import com.leteatgo.global.batch.meeting.CompleteMeetingsConfig;
 import com.leteatgo.global.batch.meeting.UpdateMeetingsStatusConfig;
 import java.util.Date;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +18,7 @@ public class BatchScheduler {
 
     private final JobLauncher jobLauncher;
     private final UpdateMeetingsStatusConfig updateMeetingsStatusConfig;
+    private final CompleteMeetingsConfig completeMeetingsConfig;
 
     // 30분마다 실행
     @Scheduled(cron = "0 0/30 * * * *")
@@ -30,6 +32,21 @@ public class BatchScheduler {
             jobLauncher.run(updateMeetingsStatusConfig.job(), jobParameters);
         } catch (Exception e) {
             log.error("UpdateMeetingsStatusConfig.run() error", e);
+        }
+    }
+
+    // 매일 자정에 실행
+    @Scheduled(cron = "0 0 0 * * *")
+    public void runCompleteMeetingsJob() {
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addDate("date", new Date())
+                .toJobParameters();
+
+        try {
+            log.info("CompleteMeetingsConfig.run() start");
+            jobLauncher.run(completeMeetingsConfig.job(), jobParameters);
+        } catch (Exception e) {
+            log.error("CompleteMeetingsConfig.run() error", e);
         }
     }
 }

--- a/src/main/java/com/leteatgo/global/batch/scheduler/BatchScheduler.java
+++ b/src/main/java/com/leteatgo/global/batch/scheduler/BatchScheduler.java
@@ -1,6 +1,6 @@
 package com.leteatgo.global.batch.scheduler;
 
-import com.leteatgo.global.batch.meeting.CancelUnmatchedMeetingsConfig;
+import com.leteatgo.global.batch.meeting.UpdateMeetingsStatusConfig;
 import java.util.Date;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,19 +16,20 @@ import org.springframework.stereotype.Component;
 public class BatchScheduler {
 
     private final JobLauncher jobLauncher;
-    private final CancelUnmatchedMeetingsConfig cancelUnmatchedMeetingsConfig;
+    private final UpdateMeetingsStatusConfig updateMeetingsStatusConfig;
 
-    @Scheduled(cron = "0 0 0/2 * * *")
-    public void run() {
+    // 30분마다 실행
+    @Scheduled(cron = "0 0/30 * * * *")
+    public void runUpdateMeetingsStatusJob() {
         JobParameters jobParameters = new JobParametersBuilder()
                 .addDate("date", new Date())
                 .toJobParameters();
 
         try {
-            log.info("BatchScheduler.run()");
-            jobLauncher.run(cancelUnmatchedMeetingsConfig.job(), jobParameters);
+            log.info("UpdateMeetingsStatusConfig.run() start");
+            jobLauncher.run(updateMeetingsStatusConfig.job(), jobParameters);
         } catch (Exception e) {
-            log.error("BatchScheduler.run() error", e);
+            log.error("UpdateMeetingsStatusConfig.run() error", e);
         }
     }
 }

--- a/src/main/java/com/leteatgo/global/batch/scheduler/BatchScheduler.java
+++ b/src/main/java/com/leteatgo/global/batch/scheduler/BatchScheduler.java
@@ -1,6 +1,8 @@
 package com.leteatgo.global.batch.scheduler;
 
 import com.leteatgo.global.batch.meeting.CompleteMeetingsConfig;
+import com.leteatgo.global.batch.meeting.RemindMeetingsBeforeOneDayConfig;
+import com.leteatgo.global.batch.meeting.RemindUpcomingMeetingsConfig;
 import com.leteatgo.global.batch.meeting.UpdateMeetingsStatusConfig;
 import java.util.Date;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +21,8 @@ public class BatchScheduler {
     private final JobLauncher jobLauncher;
     private final UpdateMeetingsStatusConfig updateMeetingsStatusConfig;
     private final CompleteMeetingsConfig completeMeetingsConfig;
+    private final RemindMeetingsBeforeOneDayConfig remindMeetingsBeforeOneDayConfig;
+    private final RemindUpcomingMeetingsConfig remindUpcomingMeetingsConfig;
 
     // 30분마다 실행
     @Scheduled(cron = "0 0/30 * * * *")
@@ -36,7 +40,8 @@ public class BatchScheduler {
     }
 
     // 매일 자정에 실행
-    @Scheduled(cron = "0 0 0 * * *")
+//    @Scheduled(cron = "0 0 0 * * *")
+    @Scheduled(cron = "0/30 * * * * *")
     public void runCompleteMeetingsJob() {
         JobParameters jobParameters = new JobParametersBuilder()
                 .addDate("date", new Date())
@@ -47,6 +52,36 @@ public class BatchScheduler {
             jobLauncher.run(completeMeetingsConfig.job(), jobParameters);
         } catch (Exception e) {
             log.error("CompleteMeetingsConfig.run() error", e);
+        }
+    }
+
+    // 매일 저녁 8시에 실행
+    @Scheduled(cron = "0 0 20 * * *")
+    public void runRemindMeetingsBeforeOneDayJob() {
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addDate("date", new Date())
+                .toJobParameters();
+
+        try {
+            log.info("RemindMeetingsConfig.run() start");
+            jobLauncher.run(remindMeetingsBeforeOneDayConfig.job(), jobParameters);
+        } catch (Exception e) {
+            log.error("RemindMeetingsConfig.run() error", e);
+        }
+    }
+
+    // 한시간마다 실행
+    @Scheduled(cron = "0 0 0/1 * * *")
+    public void runUpcomingMeetingsNotificationJob() {
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addDate("date", new Date())
+                .toJobParameters();
+
+        try {
+            log.info("UpcomingMeetingsNotificationConfig.run() start");
+            jobLauncher.run(remindUpcomingMeetingsConfig.job(), jobParameters);
+        } catch (Exception e) {
+            log.error("UpcomingMeetingsNotificationConfig.run() error", e);
         }
     }
 }

--- a/src/main/java/com/leteatgo/global/constants/BeanPrefix.java
+++ b/src/main/java/com/leteatgo/global/constants/BeanPrefix.java
@@ -4,5 +4,7 @@ public class BeanPrefix {
 
     public static final String UPDATE_MEETING_STATUS = "UpdateMeetingStatus";
     public static final String COMPLETE_MEETING = "CompleteMeeting";
+    public static final String REMIND_MEETING_BEFORE_ONE_DAY = "RemindMeetingBeforeOneDay";
+    public static final String REMIND_MEETING_COMING_SOON = "RemindMeetingComingSoon";
 
 }

--- a/src/main/java/com/leteatgo/global/constants/BeanPrefix.java
+++ b/src/main/java/com/leteatgo/global/constants/BeanPrefix.java
@@ -3,5 +3,6 @@ package com.leteatgo.global.constants;
 public class BeanPrefix {
 
     public static final String UPDATE_MEETING_STATUS = "UpdateMeetingStatus";
+    public static final String COMPLETE_MEETING = "CompleteMeeting";
 
 }

--- a/src/main/java/com/leteatgo/global/constants/BeanPrefix.java
+++ b/src/main/java/com/leteatgo/global/constants/BeanPrefix.java
@@ -2,6 +2,6 @@ package com.leteatgo.global.constants;
 
 public class BeanPrefix {
 
-    public static final String CANCEL_UNMATCHED_MEETING = "CancelUnmatchedMeeting";
+    public static final String UPDATE_MEETING_STATUS = "UpdateMeetingStatus";
 
 }

--- a/src/main/java/com/leteatgo/global/constants/Notification.java
+++ b/src/main/java/com/leteatgo/global/constants/Notification.java
@@ -5,6 +5,8 @@ public class Notification {
     public final static String SUBSCRIBE = "SSE Subscribe Success";
     public final static String MEETING_CANCEL = "[%s] 모임이 취소되었습니다.";
     public final static String MEETING_COMPLETE = "[%s] 모임이 완료되었습니다. 모임원들을 평가해주세요.";
+    public final static String MEETING_REMIND_ONE_DAY_BEFORE = "[%s] 모임 하루 전입니다. 잊지 말고 참석해주세요.";
+    public final static String MEETING_REMIND_SOON = "[%s] 모임이 %d분 후에 시작됩니다. 잊지 말고 참석해주세요.";
     public static final String NOTIFICATION_QUEUE = "notification.queue";
 
 }

--- a/src/main/java/com/leteatgo/global/constants/Notification.java
+++ b/src/main/java/com/leteatgo/global/constants/Notification.java
@@ -4,6 +4,7 @@ public class Notification {
 
     public final static String SUBSCRIBE = "SSE Subscribe Success";
     public final static String MEETING_CANCEL = "[%s] 모임이 취소되었습니다.";
+    public final static String MEETING_COMPLETE = "[%s] 모임이 완료되었습니다. 모임원들을 평가해주세요.";
     public static final String NOTIFICATION_QUEUE = "notification.queue";
 
 }

--- a/src/test/java/com/leteatgo/global/batch/meeting/UpdateMeetingsStatusConfigTest.java
+++ b/src/test/java/com/leteatgo/global/batch/meeting/UpdateMeetingsStatusConfigTest.java
@@ -52,7 +52,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 @SpringBootTest
 @ActiveProfiles("test")
 @Sql(scripts = "classpath:sql/batch-schema-h2.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
-class CancelUnmatchedMeetingsConfigTest {
+class UpdateMeetingsStatusConfigTest {
 
     @Autowired
     JobLauncherTestUtils jobLauncherTestUtils;
@@ -73,7 +73,7 @@ class CancelUnmatchedMeetingsConfigTest {
     ChatRoomRepository chatRoomRepository;
 
     @Autowired
-    CancelUnmatchedMeetingsConfig cancelUnmatchedMeetingsConfig;
+    UpdateMeetingsStatusConfig updateMeetingsStatusConfig;
 
     @MockBean
     ChatRoomEventPublisher chatRoomEventPublisher;
@@ -93,13 +93,13 @@ class CancelUnmatchedMeetingsConfigTest {
 
 
     @Test
-    void cancelUnmatchedMeetingsJobTest() throws Exception {
+    void updateMeetingsStatusJobTest() throws Exception {
         // given
         JobParameters jobParameters = new JobParametersBuilder()
                 .addDate("date", new Date())
                 .toJobParameters();
         // when
-        jobLauncherTestUtils.setJob(cancelUnmatchedMeetingsConfig.job());
+        jobLauncherTestUtils.setJob(updateMeetingsStatusConfig.job());
         JobExecution jobExecution = jobLauncherTestUtils.launchJob(jobParameters);
         // then
         assertThat(jobExecution.getStatus()).isEqualTo(BatchStatus.COMPLETED);

--- a/src/test/java/com/leteatgo/global/batch/meeting/UpdateMeetingsStatusConfigTest.java
+++ b/src/test/java/com/leteatgo/global/batch/meeting/UpdateMeetingsStatusConfigTest.java
@@ -12,6 +12,8 @@ import com.leteatgo.domain.chat.type.RoomStatus;
 import com.leteatgo.domain.meeting.dto.request.MeetingOptionsRequest;
 import com.leteatgo.domain.meeting.entity.Meeting;
 import com.leteatgo.domain.meeting.entity.MeetingOptions;
+import com.leteatgo.domain.meeting.entity.MeetingParticipant;
+import com.leteatgo.domain.meeting.repository.MeetingParticipantRepository;
 import com.leteatgo.domain.meeting.repository.MeetingRepository;
 import com.leteatgo.domain.meeting.type.AgePreference;
 import com.leteatgo.domain.meeting.type.AlcoholPreference;
@@ -31,6 +33,7 @@ import java.util.Date;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -64,6 +67,9 @@ class UpdateMeetingsStatusConfigTest {
     MeetingRepository meetingRepository;
 
     @Autowired
+    MeetingParticipantRepository meetingParticipantRepository;
+
+    @Autowired
     MemberRepository memberRepository;
 
     @Autowired
@@ -93,7 +99,8 @@ class UpdateMeetingsStatusConfigTest {
 
 
     @Test
-    void updateMeetingsStatusJobTest() throws Exception {
+    @DisplayName("모임 취소 배치 테스트")
+    void cancelMeetingsJobTest() throws Exception {
         // given
         JobParameters jobParameters = new JobParametersBuilder()
                 .addDate("date", new Date())
@@ -145,6 +152,13 @@ class UpdateMeetingsStatusConfigTest {
             meetings.add(meeting);
         }
         meetingRepository.saveAll(meetings);
+
+        // 모임원 추가
+        for (int i = 0; i < 10; i++) {
+            Meeting meeting = meetings.get(i);
+            meetingParticipantRepository.save(
+                    MeetingParticipant.builder().meeting(meeting).member(mockMember).build());
+        }
 
         // 채팅방 생성
         for (int i = 0; i < 10; i++) {


### PR DESCRIPTION
<!-- 제목은 `[#이슈번호] 제목` 으로 작성한다. ex) [#8] 결제 기능 -->

### 🌱 작업 사항
- 모임 상태 변경 배치작업들 구현 (before -> cancel, inProgress, inProgress -> completed)
  - cancel 은 이미 구현되어있었고, inProgress로 바꾸는 배치작업과 합침 (두 작업 모두 before, 모임 시작시간이 지난것을 조회했음)
    - 30분마다 수행
  - completed로 바꾸는 작업은 매일 자정에 수행되며, IN_PROGRESS 상태이고 모임시작날짜가 지난 모임들을 조회해서 바꿔줌
    - 또한, 해당 모임의 채팅방을 제거해주며, 모임 종료 알림을 보내줌 (동료 평가페이지로 유도)  
- 모임 리마인드 알림 배치작업 구현
  - `하루 전` : 매일 저녁 8시에 다음날 모임들 (IN_PROGRESS 상태이고, 모임 시작 날짜가 다음날인 모임들)을 조회해서 해당 모임의 모임원들에게 알림보내줌
  - `얼마 남지 않았을 때` : 1시간마다 수행되며, 모임이 한시간 이내에 시작되는 모임들을 조회해서 리마인드 알림(남은 시간 포함)을 보내줌

![image](https://github.com/let-eat-go/backend/assets/109774037/92a8becb-eede-4044-8d5e-78f56d36739f)


### ❓ 리뷰 포인트
- 우선 임의로 배치 주기들 설정했고, 리마인드 알림의 경우 pre기획에 있던 15분전 알림까지 구현하면 배치 주기를 정말 짧게 가져가야 할 것 같아서 구현하지 않고 `얼마 남지 않았을 때`를 추가했습니다.. 이 방식이 좋은진 모르겠습니다..!ㅠ
  - 배치 주기를 짧게 가져갈 경우, 알림을 1번만 보내는게 아닌 여러번 중복된 알림을 보낼 수도 있는데 이 부분을 해결하려면 좀 큰 공사가 될 것 같아서 포기했습니다..

<!-- ex) query가 너무 많이 나가는 것 같아요 -->
<!-- ex) service 로직 너무 뚱뚱해요 -->
<!-- ex) 테스트 어떤가요. -->

### 🦄 관련 이슈

resolves #38  <!-- pr이 머지되면 이슈가 자동으로 close되게 합니다. 만약 자동 close를 하지 않고 이슈만 링크한다면 resolves를 삭제한다.-->