### PR TITLE
[#49] 맛집 검색 API Circuit breaker 패턴 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,16 @@ repositories {
     mavenCentral()
 }
 
+ext {
+    set('springCloudVersion', "2023.0.0")
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
+}
+
 dependencies {
     // Springboot Starter
     // WEB
@@ -40,8 +50,10 @@ dependencies {
     // DB
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     // redisson
     implementation 'org.redisson:redisson-spring-boot-starter:3.23.1'
+
     // Batch
     implementation 'org.springframework.boot:spring-boot-starter-batch'
 
@@ -56,6 +68,9 @@ dependencies {
 
     // rabbitmq
     implementation 'org.springframework.boot:spring-boot-starter-amqp'
+
+    // circuit breaker
+    implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-reactor-resilience4j'
 
     // Driver
     runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/leteatgo/domain/chat/dto/response/ChatMessageResponse.java
+++ b/src/main/java/com/leteatgo/domain/chat/dto/response/ChatMessageResponse.java
@@ -1,6 +1,5 @@
 package com.leteatgo.domain.chat.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.leteatgo.domain.chat.entity.ChatMessage;
 import com.leteatgo.domain.member.entity.Member;
 import java.time.LocalDateTime;
@@ -11,7 +10,6 @@ public record ChatMessageResponse(
         Sender sender,
         String content,
         boolean isRead,
-        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime createdAt
 ) {
 

--- a/src/main/java/com/leteatgo/domain/chat/dto/response/MyChatRoomResponse.java
+++ b/src/main/java/com/leteatgo/domain/chat/dto/response/MyChatRoomResponse.java
@@ -18,7 +18,6 @@ public record MyChatRoomResponse(
             Long roomId,
             String content,
             boolean isRead,
-            @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
             LocalDateTime createdAt
     ) {
 

--- a/src/main/java/com/leteatgo/domain/chat/dto/response/MyChatRoomResponse.java
+++ b/src/main/java/com/leteatgo/domain/chat/dto/response/MyChatRoomResponse.java
@@ -1,6 +1,5 @@
 package com.leteatgo.domain.chat.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.leteatgo.global.type.RestaurantCategory;
 import java.time.LocalDateTime;
 import lombok.Builder;

--- a/src/main/java/com/leteatgo/domain/member/dto/response/MyMeetingsResponse.java
+++ b/src/main/java/com/leteatgo/domain/member/dto/response/MyMeetingsResponse.java
@@ -1,6 +1,5 @@
 package com.leteatgo.domain.member.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.leteatgo.global.type.RestaurantCategory;
 import java.time.LocalDateTime;
 import lombok.Builder;
@@ -10,7 +9,6 @@ public record MyMeetingsResponse(
         Long meetingId,
         String meetingName,
         RestaurantCategory category,
-        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime startDateTime,
         Integer maxParticipants,
         Restaurant restaurant

--- a/src/main/java/com/leteatgo/domain/tastyrestaurant/dto/response/SearchRestaurantsResponse.java
+++ b/src/main/java/com/leteatgo/domain/tastyrestaurant/dto/response/SearchRestaurantsResponse.java
@@ -1,10 +1,12 @@
 package com.leteatgo.domain.tastyrestaurant.dto.response;
 
+import com.leteatgo.domain.tastyrestaurant.entity.TastyRestaurant;
 import com.leteatgo.global.external.searchplace.dto.RestaurantContent;
 import com.leteatgo.global.external.searchplace.dto.RestaurantsResponse;
 import com.leteatgo.global.type.RestaurantCategory;
 import java.util.List;
 import lombok.Builder;
+import org.springframework.data.domain.Slice;
 
 public record SearchRestaurantsResponse(
         List<Content> contents,
@@ -21,6 +23,18 @@ public record SearchRestaurantsResponse(
                         .currentPage(currentPage)
                         .hasMore(response.getMeta().hasNext())
                         .totalCount(response.getMeta().totalCount())
+                        .build());
+    }
+
+    public static SearchRestaurantsResponse fromEntity(Slice<TastyRestaurant> slice) {
+        return new SearchRestaurantsResponse(
+                slice.getContent().stream()
+                        .map(Content::fromEntity)
+                        .toList(),
+                Pagination.builder()
+                        .currentPage(slice.getPageable().getPageNumber() + 1)
+                        .hasMore(slice.hasNext())
+                        .totalCount(-1) // slice에는 total이 없음
                         .build());
     }
 
@@ -48,6 +62,20 @@ public record SearchRestaurantsResponse(
                     .latitude(content.latitude())
                     .longitude(content.longitude())
                     .restaurantUrl(content.restaurantUrl())
+                    .build();
+        }
+
+        public static Content fromEntity(TastyRestaurant tastyRestaurant) {
+            return Content.builder()
+                    .apiId(tastyRestaurant.getApiId())
+                    .name(tastyRestaurant.getName())
+                    .category(tastyRestaurant.getCategory())
+                    .phoneNumber(tastyRestaurant.getPhoneNumber())
+                    .roadAddress(tastyRestaurant.getRoadAddress())
+                    .landAddress(tastyRestaurant.getLandAddress())
+                    .latitude(tastyRestaurant.getLatitude())
+                    .longitude(tastyRestaurant.getLongitude())
+                    .restaurantUrl(tastyRestaurant.getRestaurantUrl())
                     .build();
         }
     }

--- a/src/main/java/com/leteatgo/domain/tastyrestaurant/repository/CustomTastyRestaurantRepository.java
+++ b/src/main/java/com/leteatgo/domain/tastyrestaurant/repository/CustomTastyRestaurantRepository.java
@@ -1,0 +1,11 @@
+package com.leteatgo.domain.tastyrestaurant.repository;
+
+import com.leteatgo.domain.tastyrestaurant.dto.request.SearchRestaurantsRequest;
+import com.leteatgo.domain.tastyrestaurant.entity.TastyRestaurant;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface CustomTastyRestaurantRepository {
+
+    Slice<TastyRestaurant> searchRestaurants(SearchRestaurantsRequest request, Pageable pageable);
+}

--- a/src/main/java/com/leteatgo/domain/tastyrestaurant/repository/TastyRestaurantRepository.java
+++ b/src/main/java/com/leteatgo/domain/tastyrestaurant/repository/TastyRestaurantRepository.java
@@ -5,10 +5,10 @@ import java.util.Optional;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface TastyRestaurantRepository extends JpaRepository<TastyRestaurant, Long> {
+public interface TastyRestaurantRepository extends JpaRepository<TastyRestaurant, Long>,
+        CustomTastyRestaurantRepository {
 
     List<TastyRestaurant> findTop5ByOrderByNumberOfUsesDesc();
 
-    Optional<TastyRestaurant> findByApiId(Long kakaoId);
-
+    Optional<TastyRestaurant> findByApiId(Long apiId);
 }

--- a/src/main/java/com/leteatgo/domain/tastyrestaurant/repository/impl/CustomTastyRestaurantRepositoryImpl.java
+++ b/src/main/java/com/leteatgo/domain/tastyrestaurant/repository/impl/CustomTastyRestaurantRepositoryImpl.java
@@ -1,0 +1,87 @@
+package com.leteatgo.domain.tastyrestaurant.repository.impl;
+
+import static com.leteatgo.domain.tastyrestaurant.entity.QTastyRestaurant.tastyRestaurant;
+import static com.querydsl.core.types.dsl.MathExpressions.acos;
+import static com.querydsl.core.types.dsl.MathExpressions.cos;
+import static com.querydsl.core.types.dsl.MathExpressions.radians;
+import static com.querydsl.core.types.dsl.MathExpressions.sin;
+
+import com.leteatgo.domain.tastyrestaurant.dto.request.SearchRestaurantsRequest;
+import com.leteatgo.domain.tastyrestaurant.entity.TastyRestaurant;
+import com.leteatgo.domain.tastyrestaurant.repository.CustomTastyRestaurantRepository;
+import com.leteatgo.global.util.OrderByNull;
+import com.leteatgo.global.util.SliceUtil;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.annotation.Nullable;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
+
+@RequiredArgsConstructor
+public class CustomTastyRestaurantRepositoryImpl implements CustomTastyRestaurantRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Slice<TastyRestaurant> searchRestaurants(SearchRestaurantsRequest request,
+            Pageable pageable) {
+        NumberExpression<Double> distance = getDistance(request);
+
+        List<TastyRestaurant> contents = queryFactory.selectFrom(tastyRestaurant)
+                .where(tastyRestaurant.name.contains(request.keyword()),
+                        nearByDistance(request.radius(), distance))
+                .orderBy(sortByDistance(request.sort(), distance))
+                .fetch();
+
+        return new SliceUtil<>(contents, pageable).getSlice();
+    }
+
+    @Nullable
+    private NumberExpression<Double> getDistance(SearchRestaurantsRequest request) {
+        if (ObjectUtils.isEmpty(request.longitude()) && ObjectUtils.isEmpty(request.latitude())) {
+            return null;
+        }
+
+        Expression<Double> latitude = Expressions.constant(request.latitude());
+        Expression<Double> longitude = Expressions.constant(request.longitude());
+
+        return acos(cos(radians(latitude))
+                .multiply(cos(radians(tastyRestaurant.latitude)))
+                .multiply(cos(radians(tastyRestaurant.longitude).subtract(radians(longitude))))
+                .add(sin(radians(latitude))
+                        .multiply(sin(tastyRestaurant.latitude))))
+                .multiply(6371);
+    }
+
+    private BooleanExpression nearByDistance(Integer radius, NumberExpression<Double> distance) {
+        if (distance == null) {
+            return null;
+        }
+
+        if (ObjectUtils.isEmpty(radius)) {
+            radius = 20000; // max radius
+        }
+
+        return distance.loe(radius);
+    }
+
+    private OrderSpecifier<Double> sortByDistance(String sort, NumberExpression<Double> distance) {
+        if (!StringUtils.hasText(sort) || distance == null) {
+            return OrderByNull.DEFAULT;
+        }
+
+        if (sort.equals("distance")) {
+            return distance.desc();
+        }
+
+        return OrderByNull.DEFAULT;
+    }
+}

--- a/src/main/java/com/leteatgo/domain/tastyrestaurant/repository/impl/CustomTastyRestaurantRepositoryImpl.java
+++ b/src/main/java/com/leteatgo/domain/tastyrestaurant/repository/impl/CustomTastyRestaurantRepositoryImpl.java
@@ -57,7 +57,7 @@ public class CustomTastyRestaurantRepositoryImpl implements CustomTastyRestauran
                 .multiply(cos(radians(tastyRestaurant.latitude)))
                 .multiply(cos(radians(tastyRestaurant.longitude).subtract(radians(longitude))))
                 .add(sin(radians(latitude))
-                        .multiply(sin(tastyRestaurant.latitude))))
+                        .multiply(sin(radians(tastyRestaurant.latitude)))))
                 .multiply(6371);
     }
 

--- a/src/main/java/com/leteatgo/domain/tastyrestaurant/service/TastyRestaurantService.java
+++ b/src/main/java/com/leteatgo/domain/tastyrestaurant/service/TastyRestaurantService.java
@@ -6,11 +6,17 @@ import com.leteatgo.domain.tastyrestaurant.dto.response.SearchRestaurantsRespons
 import com.leteatgo.domain.tastyrestaurant.dto.response.VisitedRestaurantResponse;
 import com.leteatgo.domain.tastyrestaurant.dto.response.VisitedRestaurantResponse.Content;
 import com.leteatgo.domain.tastyrestaurant.repository.TastyRestaurantRepository;
+import com.leteatgo.global.dto.CustomPageRequest;
 import com.leteatgo.global.external.searchplace.client.RestaurantSearcher;
 import com.leteatgo.global.external.searchplace.dto.RestaurantsResponse;
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class TastyRestaurantService {
@@ -19,6 +25,9 @@ public class TastyRestaurantService {
     private final TastyRestaurantRepository tastyRestaurantRepository;
     private final RedisRankingService redisRankingService;
 
+    private static final String CB_SEARCH_RESTAURANTS = "searchRestaurants";
+
+    @CircuitBreaker(name = CB_SEARCH_RESTAURANTS, fallbackMethod = "searchRestaurantsFallback")
     public SearchRestaurantsResponse searchRestaurants(SearchRestaurantsRequest request) {
         RestaurantsResponse response = RestaurantSearcher.searchRestaurants(
                 request.keyword(),
@@ -30,6 +39,16 @@ public class TastyRestaurantService {
 
         redisRankingService.saveSearchKeyword(request.keyword());
         return SearchRestaurantsResponse.from(response, request.page());
+    }
+
+    public SearchRestaurantsResponse searchRestaurantsFallback(SearchRestaurantsRequest request,
+            CallNotPermittedException exception) {
+        log.info("fail searchRestaurants cause [{}: {}]", exception.getClass(),
+                exception.getMessage());
+
+        return SearchRestaurantsResponse.fromEntity(
+                tastyRestaurantRepository.searchRestaurants(request,
+                        PageRequest.of(request.page() - 1, CustomPageRequest.PAGE_SIZE)));
     }
 
     public PopularKeywordsResponse getKeywordRanking() {

--- a/src/main/java/com/leteatgo/global/config/SecurityConfig.java
+++ b/src/main/java/com/leteatgo/global/config/SecurityConfig.java
@@ -49,7 +49,7 @@ public class SecurityConfig {
 
                 .authorizeHttpRequests(authorize -> authorize
                         // static
-                        .requestMatchers("/docs/**", "/error", "/favicon.ico",
+                        .requestMatchers("/", "/docs/**", "/error", "/favicon.ico",
                                 "/v3/api-docs/**", "/ws").permitAll()
 
                         // api

--- a/src/main/java/com/leteatgo/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/leteatgo/global/security/jwt/JwtAuthenticationFilter.java
@@ -32,6 +32,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private static final String[] WHITELIST = {
             "/docs/**", // swagger
+            "/error",
+            "/favicon.ico",
             "/v3/api-docs/**", // swagger
             "/api/auth/signup", // 회원가입
             "/api/auth/signin", // 로그인
@@ -45,7 +47,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             "/api/meetings/detail/**", // 모임 상세 조회
             "/api/meetings/list", // 모임 목록 조회
             "/api/meetings/search", // 모임 검색
-            "/ws" // websocket connection
+            "/ws", // websocket connection,
+            "/"
     };
 
     private final JwtTokenProvider jwtTokenProvider;

--- a/src/main/java/com/leteatgo/global/util/OrderByNull.java
+++ b/src/main/java/com/leteatgo/global/util/OrderByNull.java
@@ -1,0 +1,14 @@
+package com.leteatgo.global.util;
+
+import com.querydsl.core.types.NullExpression;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+
+public class OrderByNull extends OrderSpecifier {
+
+    public static final OrderByNull DEFAULT = new OrderByNull();
+
+    private OrderByNull() {
+        super(Order.ASC, NullExpression.DEFAULT, NullHandling.Default);
+    }
+}

--- a/src/main/resources/application-common.yml
+++ b/src/main/resources/application-common.yml
@@ -53,3 +53,28 @@ spring:
 aws:
   s3:
     bucket: ${S3_BUCKET}
+
+resilience4j:
+  circuitbreaker:
+    configs:
+      default:
+        failure-rate-threshold: 10
+        slow-call-rate-threshold: 10
+        slow-call-duration-threshold: 500
+        wait-duration-in-open-state: 30000
+        permitted-number-of-calls-in-half-open-state: 5
+        minimum-number-of-calls: 10
+        register-health-indicator: true
+    instances:
+      searchRestaurants:
+        base-config: default
+        failure-rate-threshold: 50
+        minimum-number-of-calls: 100
+
+management:
+  endpoint:
+    health:
+      show-details: always
+  health:
+    circuitbreakers:
+      enabled: true

--- a/src/test/java/com/leteatgo/domain/tastyrestaurant/service/TastyRestaurantServiceTest.java
+++ b/src/test/java/com/leteatgo/domain/tastyrestaurant/service/TastyRestaurantServiceTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import com.leteatgo.domain.tastyrestaurant.dto.request.SearchRestaurantsRequest;
 import com.leteatgo.domain.tastyrestaurant.dto.response.PopularKeywordsResponse;
@@ -13,10 +15,14 @@ import com.leteatgo.domain.tastyrestaurant.dto.response.SearchRestaurantsRespons
 import com.leteatgo.domain.tastyrestaurant.dto.response.VisitedRestaurantResponse;
 import com.leteatgo.domain.tastyrestaurant.entity.TastyRestaurant;
 import com.leteatgo.domain.tastyrestaurant.repository.TastyRestaurantRepository;
+import com.leteatgo.global.dto.CustomPageRequest;
 import com.leteatgo.global.external.searchplace.client.RestaurantSearcher;
 import com.leteatgo.global.external.searchplace.client.kakao.dto.KakaoRestaurantsResponse;
 import com.leteatgo.global.external.searchplace.client.kakao.dto.KakaoRestaurantsResponse.Document;
 import com.leteatgo.global.external.searchplace.client.kakao.dto.KakaoRestaurantsResponse.Meta;
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -25,6 +31,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.SliceImpl;
 
 @ExtendWith(MockitoExtension.class)
 class TastyRestaurantServiceTest {
@@ -61,10 +70,20 @@ class TastyRestaurantServiceTest {
 
         Meta meta = new Meta(true, 1234);
 
+        SearchRestaurantsRequest request = SearchRestaurantsRequest.builder()
+                .keyword(keyword)
+                .latitude(127.06283)
+                .longitude(37.51432)
+                .build();
+
         @Test
         @DisplayName("성공 - 키워드 검색")
         void searchRestaurants() {
             // given
+            SearchRestaurantsRequest request = SearchRestaurantsRequest.builder()
+                    .keyword(keyword)
+                    .build();
+
             given(searchRestaurantClient.searchRestaurants(keyword, 1,
                     null, null, null, null))
                     .willReturn(new KakaoRestaurantsResponse(documents, meta));
@@ -72,10 +91,6 @@ class TastyRestaurantServiceTest {
             doNothing().when(redisRankingService).saveSearchKeyword(keyword);
 
             // when
-            SearchRestaurantsRequest request = SearchRestaurantsRequest.builder()
-                    .keyword(keyword)
-                    .build();
-
             SearchRestaurantsResponse response = tastyRestaurantService.searchRestaurants(
                     request);
 
@@ -95,18 +110,47 @@ class TastyRestaurantServiceTest {
             doNothing().when(redisRankingService).saveSearchKeyword(any());
 
             // when
-            SearchRestaurantsRequest request = SearchRestaurantsRequest.builder()
-                    .keyword(keyword)
-                    .latitude(127.06283)
-                    .longitude(37.51432)
-                    .build();
-
             SearchRestaurantsResponse response = tastyRestaurantService.searchRestaurants(
                     request);
 
             // then
             assertEquals(1, response.pagination().currentPage());
             assertEquals(KOREAN_CUISINE, response.contents().get(0).category());
+        }
+
+        @Test
+        @DisplayName("fallback 메서드")
+        void searchRestaurants_fallback() {
+            // given
+            Pageable pageable = PageRequest.of(request.page() - 1,
+                    CustomPageRequest.PAGE_SIZE);
+
+            List<TastyRestaurant> contents = List.of(TastyRestaurant.builder()
+                    .name("삼환소한마리")
+                    .category(KOREAN_CUISINE)
+                    .phoneNumber("02-545-2429")
+                    .roadAddress("도로명")
+                    .landAddress("지번")
+                    .latitude(127.06283102249932)
+                    .longitude(37.514322572335935)
+                    .restaurantUrl("http://place.map.kakao.com/8137464")
+                    .build());
+
+            given(tastyRestaurantRepository.searchRestaurants(request, pageable))
+                    .willReturn(new SliceImpl<>(contents, pageable, false));
+
+            // when
+            CallNotPermittedException callNotPermittedException =
+                    CallNotPermittedException.createCallNotPermittedException(
+                    CircuitBreaker.of("searchRestaurants", CircuitBreakerConfig.ofDefaults()));
+
+            SearchRestaurantsResponse response = tastyRestaurantService.searchRestaurantsFallback(
+                    request, callNotPermittedException);
+
+            // then
+            verify(tastyRestaurantRepository, times(1))
+                    .searchRestaurants(request, pageable);
+            assertEquals(1, response.pagination().currentPage());
         }
     }
 

--- a/src/test/java/com/leteatgo/http/actuator.http
+++ b/src/test/java/com/leteatgo/http/actuator.http
@@ -1,0 +1,1 @@
+GET {{host}}/actuator/health

--- a/src/test/java/com/leteatgo/http/auth.http
+++ b/src/test/java/com/leteatgo/http/auth.http
@@ -3,6 +3,6 @@ POST {{host}}/api/auth/signin
 Content-Type: application/json
 
 {
-  "email": "test2@naver.com",
+  "email": "test@gmail.com",
   "password": "1!qweqwe"
 }

--- a/src/test/java/com/leteatgo/http/tastyRestaurant.http
+++ b/src/test/java/com/leteatgo/http/tastyRestaurant.http
@@ -2,7 +2,7 @@
 GET {{host}}/api/tasty-restaurants/search?keyword=낙지
 
 ### search restaurants with distance
-GET {{host}}/api/tasty-restaurants/search?keyword=감자탕&longitude=127.06283102249932&latitude=37.514322572335935&sort=distance
+GET {{host}}/api/tasty-restaurants/search?keyword=낙지&longitude=127.06283102249932&latitude=37.514322572335935
 
 ### get popular keywords
 GET {{host}}/api/tasty-restaurants/popular


### PR DESCRIPTION
<!-- 제목은 `[#이슈번호] 제목` 으로 작성한다. ex) [#8] 결제 기능 -->

### 🌱 작업 사항
- 맛집 검색 API 장애 발생 시 서킷 브레이커 패턴을 적용하여 장애 상황 대응
### ❓ 리뷰 포인트
- 서킷 브레이커 설정 
  - 적용한 설정에 대한 설명은 [노션](https://kingseungil.notion.site/CircuitBreaker-dbbf840521e6413d95c46dfbb92a8c5c?pvs=4)에 정리해두었습니다. 
- 서킷 브레이커 동작 과정
  - 맛집 검색 메서드에서 exception이 발생하면 failCalls가 누적됩니다.
  - failCalls가 설정한 횟수만큼 누적되면 서킷 브레이커가 OPEN 됩니다.
  - 서킷 브레이커가 OPEN되면 fallback 메서드를 통해 응답됩니다.
    - fallback 메서드는 exception별로 구분할 수 있습니다. 현재는 기존에 동작하는 searchRestaurants 메서드가 사용 불능 상태로 여겨질 때에만(서킷 OPEN) 응답을 대체하기 위해 CallNotPermittedException이 발생하는 기준으로 적용하였습니다.
  - OPEN 상태에서 설정한 시간이 지나면 HALF_OPEN상태로 변경되고, HALF_OPEN 상태에서 failCalls가 허용되는 요청수를 넘어서면 다시 OPEN 상태로 변경됩니다.
  - 만약 카카오 api 요청 시 500 에러가 떨어지면 failCalls의 값과 상관없이 즉시 fallback 메서드로 핸들링해야하는데, 이 부분은 조금 더 찾아보고 추가해보도록 하겠습니다.
- fallback 메서드
  - 카카오 api 장애시 DB의 맛집 테이블에서 동일한 검색 조건으로 쿼리하여 응답합니다.
  - 이때 거리 기반 조회를 위해 두 좌표 사이의 거리를 구하는 Haversine 공식을 사용하였습니다.
    - 발생하는 쿼리의 실행 type이 ALL이라서 좌표에 인덱스를 추가해보았지만 변하지 않았습니다.. like(%query%)라서 그런것 같습니다.
- 참고) 서킷 브레이커 패턴은 외부 API 사용과 상관없이 다른 서비스를 호출하는 MSA 환경에서는 필수 패턴이라고 합니다. 알고 있으면 좋을 것 같아요! 
<!-- ex) query가 너무 많이 나가는 것 같아요 -->
<!-- ex) service 로직 너무 뚱뚱해요 -->
<!-- ex) 테스트 어떤가요. -->

### 🦄 관련 이슈

resolves #49 <!-- pr이 머지되면 이슈가 자동으로 close되게 합니다. 만약 자동 close를 하지 않고 이슈만 링크한다면 resolves를 삭제한다.-->