### PR TITLE
[#82] 타 회원 모임 조회 API 추가

### DIFF
--- a/src/main/java/com/leteatgo/domain/meeting/repository/CustomMeetingParticipantRepository.java
+++ b/src/main/java/com/leteatgo/domain/meeting/repository/CustomMeetingParticipantRepository.java
@@ -1,7 +1,7 @@
 package com.leteatgo.domain.meeting.repository;
 
 import com.leteatgo.domain.chat.dto.response.MyChatRoomResponse;
-import com.leteatgo.domain.member.dto.response.MyMeetingsResponse;
+import com.leteatgo.domain.member.dto.response.MemberMeetingsResponse;
 import com.leteatgo.domain.member.entity.Member;
 import com.leteatgo.domain.member.type.SearchType;
 import org.springframework.data.domain.Pageable;
@@ -11,6 +11,6 @@ public interface CustomMeetingParticipantRepository {
 
     Slice<MyChatRoomResponse> findAllMyChatRooms(Member member, Pageable pageable);
 
-    Slice<MyMeetingsResponse> findAllMyMeetings(Member member, SearchType searchType,
+    Slice<MemberMeetingsResponse> findAllMyMeetings(Member member, SearchType searchType,
             Pageable pageable);
 }

--- a/src/main/java/com/leteatgo/domain/meeting/repository/impl/CustomMeetingParticipantRepositoryImpl.java
+++ b/src/main/java/com/leteatgo/domain/meeting/repository/impl/CustomMeetingParticipantRepositoryImpl.java
@@ -12,8 +12,8 @@ import com.leteatgo.domain.chat.entity.QChatMessage;
 import com.leteatgo.domain.chat.type.RoomStatus;
 import com.leteatgo.domain.meeting.repository.CustomMeetingParticipantRepository;
 import com.leteatgo.domain.meeting.type.MeetingStatus;
-import com.leteatgo.domain.member.dto.response.MyMeetingsResponse;
-import com.leteatgo.domain.member.dto.response.MyMeetingsResponse.Restaurant;
+import com.leteatgo.domain.member.dto.response.MemberMeetingsResponse;
+import com.leteatgo.domain.member.dto.response.MemberMeetingsResponse.Restaurant;
 import com.leteatgo.domain.member.entity.Member;
 import com.leteatgo.domain.member.type.SearchType;
 import com.leteatgo.global.util.SliceUtil;
@@ -69,16 +69,17 @@ public class CustomMeetingParticipantRepositoryImpl implements CustomMeetingPart
     }
 
     @Override
-    public Slice<MyMeetingsResponse> findAllMyMeetings(Member member, SearchType searchType,
+    public Slice<MemberMeetingsResponse> findAllMyMeetings(Member member, SearchType searchType,
             Pageable pageable) {
-        List<MyMeetingsResponse> contents = queryFactory.select(
-                        Projections.constructor(MyMeetingsResponse.class,
+        List<MemberMeetingsResponse> contents = queryFactory.select(
+                        Projections.constructor(MemberMeetingsResponse.class,
                                 meeting.id,
                                 meeting.name,
                                 meeting.region.name,
                                 meeting.restaurantCategory,
                                 meeting.startDateTime,
                                 meeting.maxParticipants,
+                                meeting.host.eq(member), // isHost
                                 Projections.constructor(Restaurant.class,
                                         tastyRestaurant.id,
                                         tastyRestaurant.name,

--- a/src/main/java/com/leteatgo/domain/member/controller/MemberController.java
+++ b/src/main/java/com/leteatgo/domain/member/controller/MemberController.java
@@ -2,7 +2,7 @@ package com.leteatgo.domain.member.controller;
 
 import com.leteatgo.domain.member.dto.request.UpdateInfoRequest;
 import com.leteatgo.domain.member.dto.response.MemberProfileResponse;
-import com.leteatgo.domain.member.dto.response.MyMeetingsResponse;
+import com.leteatgo.domain.member.dto.response.MemberMeetingsResponse;
 import com.leteatgo.domain.member.service.MemberService;
 import com.leteatgo.domain.member.type.SearchType;
 import com.leteatgo.global.dto.CustomPageRequest;
@@ -90,12 +90,12 @@ public class MemberController {
      */
     @RoleUser
     @GetMapping("/meetings/me")
-    public ResponseEntity<SliceResponse<MyMeetingsResponse>> myMeetings(
+    public ResponseEntity<SliceResponse<MemberMeetingsResponse>> myMeetings(
             @RequestParam SearchType type,
             @Valid CustomPageRequest request,
             @AuthenticationPrincipal UserDetails userDetails) {
         return ResponseEntity.ok(new SliceResponse<>(
-                memberService.myMeetings(type, request,
+                memberService.memberMeetings(type, request,
                         Long.parseLong(userDetails.getUsername()))));
     }
 
@@ -110,5 +110,23 @@ public class MemberController {
     public ResponseEntity<MemberProfileResponse> memberProfile(
             @PathVariable Long memberId) {
         return ResponseEntity.ok(memberService.getProfile(memberId));
+    }
+
+    /**
+     * 타 회원 모임 목록 조회
+     *
+     * @param memberId 타 회원 id
+     * @param type     조회 타입(모임 예정, 모임 완료, 내가 생성한 모임)
+     * @param request  요청 페이지
+     * @return 모임 목록
+     */
+    @RoleUser
+    @GetMapping("/{memberId}/meetings")
+    public ResponseEntity<SliceResponse<MemberMeetingsResponse>> memberMeetings(
+            @PathVariable Long memberId,
+            @RequestParam SearchType type,
+            @Valid CustomPageRequest request) {
+        return ResponseEntity.ok(new SliceResponse<>(
+                memberService.memberMeetings(type, request, memberId)));
     }
 }

--- a/src/main/java/com/leteatgo/domain/member/dto/response/MemberMeetingsResponse.java
+++ b/src/main/java/com/leteatgo/domain/member/dto/response/MemberMeetingsResponse.java
@@ -5,13 +5,14 @@ import java.time.LocalDateTime;
 import lombok.Builder;
 
 @Builder
-public record MyMeetingsResponse(
+public record MemberMeetingsResponse(
         Long meetingId,
         String meetingName,
         String region,
         RestaurantCategory category,
         LocalDateTime startDateTime,
         Integer maxParticipants,
+        boolean isHost,
         Restaurant restaurant
 ) {
 

--- a/src/main/java/com/leteatgo/domain/member/service/MemberService.java
+++ b/src/main/java/com/leteatgo/domain/member/service/MemberService.java
@@ -6,7 +6,7 @@ import static com.leteatgo.global.exception.ErrorCode.NOT_FOUND_MEMBER;
 import com.leteatgo.domain.meeting.repository.MeetingParticipantRepository;
 import com.leteatgo.domain.member.dto.request.UpdateInfoRequest;
 import com.leteatgo.domain.member.dto.response.MemberProfileResponse;
-import com.leteatgo.domain.member.dto.response.MyMeetingsResponse;
+import com.leteatgo.domain.member.dto.response.MemberMeetingsResponse;
 import com.leteatgo.domain.member.entity.Member;
 import com.leteatgo.domain.member.exception.MemberException;
 import com.leteatgo.domain.member.repository.MemberRepository;
@@ -67,7 +67,7 @@ public class MemberService {
         }
     }
 
-    public Slice<MyMeetingsResponse> myMeetings(SearchType searchType,
+    public Slice<MemberMeetingsResponse> memberMeetings(SearchType searchType,
             CustomPageRequest request, Long memberId) {
         Member member = getMemberOrThrow(memberId);
         return meetingParticipantRepository.findAllMyMeetings(member, searchType,

--- a/src/test/java/com/leteatgo/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/leteatgo/domain/member/service/MemberServiceTest.java
@@ -12,8 +12,8 @@ import static org.mockito.Mockito.doNothing;
 import com.leteatgo.domain.meeting.repository.MeetingParticipantRepository;
 import com.leteatgo.domain.member.dto.request.UpdateInfoRequest;
 import com.leteatgo.domain.member.dto.response.MemberProfileResponse;
-import com.leteatgo.domain.member.dto.response.MyMeetingsResponse;
-import com.leteatgo.domain.member.dto.response.MyMeetingsResponse.Restaurant;
+import com.leteatgo.domain.member.dto.response.MemberMeetingsResponse;
+import com.leteatgo.domain.member.dto.response.MemberMeetingsResponse.Restaurant;
 import com.leteatgo.domain.member.entity.Member;
 import com.leteatgo.domain.member.exception.MemberException;
 import com.leteatgo.domain.member.repository.MemberRepository;
@@ -64,12 +64,12 @@ class MemberServiceTest {
             .build();
 
     @Nested
-    @DisplayName("내 정보 조회 메서드")
-    class MyInformationMethod {
+    @DisplayName("회원 정보 조회 메서드")
+    class MemberProfileMethod {
 
         @Test
         @DisplayName("성공")
-        void myInformation() {
+        void getProfile() {
             // given
             given(memberRepository.findById(memberId))
                     .willReturn(Optional.of(member));
@@ -83,7 +83,7 @@ class MemberServiceTest {
 
         @Test
         @DisplayName("실패 - 존재하지 않는 회원")
-        void myInformation_not_found_member() {
+        void getProfile_not_found_member() {
             // given
             given(memberRepository.findById(memberId))
                     .willReturn(Optional.empty());
@@ -98,7 +98,7 @@ class MemberServiceTest {
 
         @Test
         @DisplayName("실패 - 이미 삭제된 회원")
-        void myInformation_already_deleted() {
+        void getProfile_already_deleted() {
             // given
             member.setDeletedAt(LocalDateTime.now());
 
@@ -256,18 +256,19 @@ class MemberServiceTest {
     }
 
     @Nested
-    @DisplayName("내 모임 목록 조회 메서드")
-    class MyMeetingsMethod {
+    @DisplayName("회원 모임 목록 조회 메서드")
+    class MemberMeetingsMethod {
 
         SearchType type = SearchType.CREATED;
         CustomPageRequest request = new CustomPageRequest(1);
 
-        MyMeetingsResponse response = MyMeetingsResponse.builder()
+        MemberMeetingsResponse response = MemberMeetingsResponse.builder()
                 .meetingId(1L)
                 .meetingName("모여라 참깨")
                 .region("강남구")
                 .category(ASIAN_CUISINE)
                 .maxParticipants(3)
+                .isHost(true)
                 .restaurant(Restaurant.builder()
                         .id(1L)
                         .name("어머니대성집")
@@ -276,13 +277,13 @@ class MemberServiceTest {
                         .build())
                 .build();
 
-        List<MyMeetingsResponse> contents = List.of(response);
+        List<MemberMeetingsResponse> contents = List.of(response);
         Pageable pageable = PageRequest.of(request.page(), CustomPageRequest.PAGE_SIZE);
-        SliceImpl<MyMeetingsResponse> slice = new SliceImpl<>(contents, pageable, true);
+        SliceImpl<MemberMeetingsResponse> slice = new SliceImpl<>(contents, pageable, true);
 
         @Test
         @DisplayName("성공")
-        void myMeetings() {
+        void memberMeetings() {
             // given
             given(memberRepository.findById(memberId))
                     .willReturn(Optional.of(member));
@@ -291,8 +292,8 @@ class MemberServiceTest {
                     .willReturn(slice);
 
             // when
-            Slice<MyMeetingsResponse> responses =
-                    memberService.myMeetings(type, request, memberId);
+            Slice<MemberMeetingsResponse> responses =
+                    memberService.memberMeetings(type, request, memberId);
 
             // then
             assertEquals(1, responses.getContent().size());
@@ -301,7 +302,7 @@ class MemberServiceTest {
 
         @Test
         @DisplayName("실패 - 존재하지 않는 회원")
-        void myMeetings_not_found_member() {
+        void memberMeetings_not_found_member() {
             // given
             given(memberRepository.findById(memberId))
                     .willReturn(Optional.empty());
@@ -309,7 +310,7 @@ class MemberServiceTest {
             // when
             // then
             assertThatThrownBy(() ->
-                    memberService.myMeetings(type, request, memberId))
+                    memberService.memberMeetings(type, request, memberId))
                     .isInstanceOf(MemberException.class)
                     .hasMessageContaining(NOT_FOUND_MEMBER.getErrorMessage());
         }

--- a/src/test/java/com/leteatgo/http/member.http
+++ b/src/test/java/com/leteatgo/http/member.http
@@ -24,4 +24,4 @@ Content-Type: multipart/form-data
 DELETE {{host}}/api/members
 
 ### my meetings
-GET {{host}}/api/members/meetings/me?type=created&page=1
+GET {{host}}/api/members/meetings/me?type=SCHEDULED&page=1


### PR DESCRIPTION
<!-- 제목은 `[#이슈번호] 제목` 으로 작성한다. ex) [#8] 결제 기능 -->

### 🌱 작업 사항
- 타 회원 모임 조회 API 추가
- 내 모임 목록 조회 응답값에 host인지 구별하는 값 추가
### ❓ 리뷰 포인트
- 단순 작업입니다.
- 내 모임 목록 조회와 로직이 같기 때문에 공통으로 사용하였습니다.
<!-- ex) query가 너무 많이 나가는 것 같아요 -->
<!-- ex) service 로직 너무 뚱뚱해요 -->
<!-- ex) 테스트 어떤가요. -->

### 🦄 관련 이슈

resolves #82  <!-- pr이 머지되면 이슈가 자동으로 close되게 합니다. 만약 자동 close를 하지 않고 이슈만 링크한다면 resolves를 삭제한다.-->