### PR TITLE
[#89] jwtFilter 리팩토링 및 알림 구독 수정

### DIFF
--- a/src/main/java/com/leteatgo/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/leteatgo/domain/notification/controller/NotificationController.java
@@ -1,9 +1,11 @@
 package com.leteatgo.domain.notification.controller;
 
+import static com.leteatgo.global.exception.ErrorCode.NEED_LOGIN;
 import static org.springframework.http.MediaType.TEXT_EVENT_STREAM_VALUE;
 
 import com.leteatgo.domain.notification.dto.NotificationDto;
 import com.leteatgo.domain.notification.event.NotificationEvent;
+import com.leteatgo.domain.notification.exception.NotificationException;
 import com.leteatgo.domain.notification.service.NotificationService;
 import com.leteatgo.domain.notification.type.NotificationType;
 import com.leteatgo.global.dto.CustomPageRequest;
@@ -11,6 +13,7 @@ import com.leteatgo.global.dto.SliceResponse;
 import com.leteatgo.global.security.annotation.RoleUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.ObjectUtils;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -32,10 +35,12 @@ public class NotificationController {
 
     // 알림 구독
     @GetMapping(value = "/subscribe", produces = TEXT_EVENT_STREAM_VALUE)
-    @RoleUser
     public ResponseEntity<SseEmitter> subscribe(
             @AuthenticationPrincipal UserDetails userDetails
     ) {
+        if (ObjectUtils.isEmpty(userDetails)) {
+            throw new NotificationException(NEED_LOGIN);
+        }
         return ResponseEntity.ok(notificationService.subscribe(userDetails.getUsername()));
     }
 

--- a/src/main/java/com/leteatgo/global/config/SecurityConfig.java
+++ b/src/main/java/com/leteatgo/global/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.leteatgo.global.config;
 import com.leteatgo.global.security.handler.CustomAccessDeniedHandler;
 import com.leteatgo.global.security.handler.CustomAuthenticationEntryPoint;
 import com.leteatgo.global.security.jwt.JwtAuthenticationFilter;
+import com.leteatgo.global.security.jwt.JwtFailureFilter;
 import com.leteatgo.global.security.oauth.handler.CustomOAuth2FailureHandler;
 import com.leteatgo.global.security.oauth.handler.CustomOAuth2SuccessHandler;
 import com.leteatgo.global.security.oauth.service.CustomOAuth2UserService;
@@ -26,6 +27,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtFailureFilter jwtFailureFilter;
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
     private final CustomOAuth2SuccessHandler customOAuth2SuccessHandler;
@@ -81,6 +83,7 @@ public class SecurityConfig {
 
                 .addFilterBefore(jwtAuthenticationFilter,
                         UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtFailureFilter, JwtAuthenticationFilter.class)
 
                 .exceptionHandling(exception -> exception
                         .authenticationEntryPoint(customAuthenticationEntryPoint)

--- a/src/main/java/com/leteatgo/global/exception/ErrorCode.java
+++ b/src/main/java/com/leteatgo/global/exception/ErrorCode.java
@@ -78,7 +78,8 @@ public enum ErrorCode {
 
     // notification
     NOT_FOUND_NOTIFICATION(BAD_REQUEST, "존재하지 않는 알림입니다."),
-    CANNOT_READ_NOTIFICATION(BAD_REQUEST, "해당 알림을 읽을 수 없습니다.");
+    CANNOT_READ_NOTIFICATION(BAD_REQUEST, "해당 알림을 읽을 수 없습니다."),
+    NEED_LOGIN(UNAUTHORIZED, "SSE 연결을 위해서는 로그인이 필요합니다.");
 
     private final HttpStatus httpStatus;
     private final String errorMessage;

--- a/src/main/java/com/leteatgo/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/leteatgo/global/security/jwt/JwtAuthenticationFilter.java
@@ -48,13 +48,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             "/api/meetings/list", // 모임 목록 조회
             "/api/meetings/search", // 모임 검색
             "/ws", // websocket connection,
-            "/",
-            "/api/notification/subscribe"
+            "/"
     };
 
     private final JwtTokenProvider jwtTokenProvider;
     private final AntPathMatcher antPathMatcher = new AntPathMatcher();
-    private final ObjectMapper objectMapper = new ObjectMapper();
 
 
     @Override
@@ -67,14 +65,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             return;
         }
 
-        try {
-            String accessToken = resolveToken(request);
-            validateAndReissueToken(accessToken, response);
-            filterChain.doFilter(request, response);
-        } catch (Exception e) {
-            log.error("Exception is occurred. ", e);
-            handleException(e, response);
-        }
+        String accessToken = resolveToken(request);
+        validateAndReissueToken(accessToken, response);
+        filterChain.doFilter(request, response);
     }
 
     private String resolveToken(HttpServletRequest request) {
@@ -100,22 +93,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 
-    private void handleException(Exception e, HttpServletResponse response) throws IOException {
-        if (e instanceof TokenException) {
-            sendErrorResponse(((TokenException) e).getErrorCode(), response);
-        } else {
-            log.error("doFilterInternal : ", e);
-            sendErrorResponse(INTERNAL_ERROR, response);
-        }
-    }
-
-
-    private void sendErrorResponse(ErrorCode errorCode, HttpServletResponse response)
-            throws IOException {
-        ErrorResponse errorResponse = new ErrorResponse(errorCode, errorCode.getErrorMessage());
-        response.setStatus(errorCode.getHttpStatus().value());
-        response.setContentType("application/json;charset=utf-8");
-        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
-    }
-
+//    private void handleException(Exception e, HttpServletResponse response) throws IOException {
+//        if (e instanceof TokenException) {
+//            sendErrorResponse(((TokenException) e).getErrorCode(), response);
+//        } else {
+//            log.error("doFilterInternal : ", e);
+//            sendErrorResponse(INTERNAL_ERROR, response);
+//        }
 }

--- a/src/main/java/com/leteatgo/global/security/jwt/JwtFailureFilter.java
+++ b/src/main/java/com/leteatgo/global/security/jwt/JwtFailureFilter.java
@@ -1,0 +1,41 @@
+package com.leteatgo.global.security.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.leteatgo.domain.auth.exception.TokenException;
+import com.leteatgo.domain.notification.exception.NotificationException;
+import com.leteatgo.global.exception.ErrorCode;
+import com.leteatgo.global.exception.dto.ErrorResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+public class JwtFailureFilter extends OncePerRequestFilter {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+
+        try {
+            filterChain.doFilter(request, response);
+        } catch (TokenException e) {
+            sendErrorResponse(e.getErrorCode(), response);
+        }
+    }
+
+    private void sendErrorResponse(ErrorCode errorCode, HttpServletResponse response)
+            throws IOException {
+        ErrorResponse errorResponse = new ErrorResponse(errorCode, errorCode.getErrorMessage());
+        response.setStatus(errorCode.getHttpStatus().value());
+        response.setContentType("application/json;charset=utf-8");
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}


### PR DESCRIPTION
<!-- 제목은 `[#이슈번호] 제목` 으로 작성한다. ex) [#8] 결제 기능 -->

### 🌱 작업 사항
- JwtAuthenticationFilter에서 TokenException 처리하던거 따로 JwtFailureFilter에서 처리하도록 수정
- 알림 구독 시 로그인 안한 유저도 api 호출 가능하도록 수정 (access deny 오류)
### ❓ 리뷰 포인트

<!-- ex) query가 너무 많이 나가는 것 같아요 -->
<!-- ex) service 로직 너무 뚱뚱해요 -->
<!-- ex) 테스트 어떤가요. -->

### 🦄 관련 이슈

resolves #89  <!-- pr이 머지되면 이슈가 자동으로 close되게 합니다. 만약 자동 close를 하지 않고 이슈만 링크한다면 resolves를 삭제한다.-->